### PR TITLE
feat: add fitting kind to vim.ui.select

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -127,11 +127,15 @@ M.delete = function(name, opts)
       vim.notify("No saved sessions", vim.log.levels.WARN)
       return
     end
-    vim.ui.select(sessions, { prompt = "Delete session" }, function(selected)
-      if selected then
-        M.delete(selected)
+    vim.ui.select(
+      sessions,
+      { kind = "resession_delete", prompt = "Delete session" },
+      function(selected)
+        if selected then
+          M.delete(selected)
+        end
       end
-    end)
+    )
     return
   end
   local filename = util.get_session_file(name, opts.dir)
@@ -379,7 +383,7 @@ M.load = function(name, opts)
       vim.notify("No saved sessions", vim.log.levels.WARN)
       return
     end
-    local select_opts = { prompt = "Load session" }
+    local select_opts = { kind = "resession_load", prompt = "Load session" }
     if config.load_detail then
       local session_data = {}
       for _, session_name in ipairs(sessions) do


### PR DESCRIPTION
This adds the kinds "resession_delete" and "resession_load" for the call to `vim.ui.select`.

Helps differentiate between seletors when using something like [dressing.nvim](https://github.com/stevearc/dressing.nvim).