### PR TITLE
Clean up some of the docstrings

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -61,7 +61,7 @@ M.load_extension = function(name, opts)
 end
 
 ---Get the name of the current session
----@return nil|string
+---@return string?
 M.get_current = function()
   local tabpage = vim.api.nvim_get_current_tabpage()
   return tab_sessions[tabpage] or current_session
@@ -75,7 +75,7 @@ M.detach = function()
 end
 
 ---List all available saved sessions
----@param opts nil|resession.ListOpts
+---@param opts resession.ListOpts?
 ---    dir nil|string Name of directory to save to (overrides config.dir)
 ---@return string[]
 M.list = function(opts)
@@ -115,7 +115,7 @@ end
 
 ---Delete a saved session
 ---@param name string
----@param opts nil|resession.DeleteOpts
+---@param opts resession.DeleteOpts?
 ---    dir nil|string Name of directory to save to (overrides config.dir)
 M.delete = function(name, opts)
   opts = opts or {}
@@ -153,7 +153,7 @@ end
 ---    attach nil|boolean Stay attached to session after saving (default true)
 ---    notify nil|boolean Notify on success
 ---    dir nil|string Name of directory to save to (overrides config.dir)
----@param target_tabpage nil|integer
+---@param target_tabpage integer?
 local function save(name, opts, target_tabpage)
   local config = require("resession.config")
   local files = require("resession.files")
@@ -239,8 +239,8 @@ local function save(name, opts, target_tabpage)
 end
 
 ---Save a session to disk
----@param name nil|string
----@param opts nil|resession.SaveOpts
+---@param name string?
+---@param opts resession.SaveOpts?
 ---    attach nil|boolean Stay attached to session after saving (default true)
 ---    notify nil|boolean Notify on success
 ---    dir nil|string Name of directory to save to (overrides config.dir)
@@ -272,7 +272,7 @@ end
 
 ---Save a tab-scoped session
 ---@param name string
----@param opts nil|resession.SaveOpts
+---@param opts resession.SaveOpts?
 ---    attach nil|boolean Stay attached to session after saving (default true)
 ---    notify nil|boolean Notify on success
 ---    dir nil|string Name of directory to save to (overrides config.dir)
@@ -304,7 +304,7 @@ M.save_tab = function(name, opts)
 end
 
 ---Save all current sessions to disk
----@param opts nil|table
+---@param opts table?
 ---    notify nil|boolean
 M.save_all = function(opts)
   opts = vim.tbl_extend("keep", opts or {}, {
@@ -359,8 +359,8 @@ end
 
 local _is_loading = false
 ---Load a session
----@param name nil|string
----@param opts nil|resession.LoadOpts
+---@param name string?
+---@param opts resession.LoadOpts?
 ---    attach nil|boolean Stay attached to session after loading (default true)
 ---    reset nil|boolean|"auto" Close everthing before loading the session (default "auto")
 ---    silence_errors nil|boolean Don't error when trying to load a missing session

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -114,7 +114,7 @@ local function remove_tabpage_session(name)
 end
 
 ---Delete a saved session
----@param name string
+---@param name string?
 ---@param opts resession.DeleteOpts?
 ---    dir nil|string Name of directory to save to (overrides config.dir)
 M.delete = function(name, opts)
@@ -271,7 +271,7 @@ M.save = function(name, opts)
 end
 
 ---Save a tab-scoped session
----@param name string
+---@param name string?
 ---@param opts resession.SaveOpts?
 ---    attach nil|boolean Stay attached to session after saving (default true)
 ---    notify nil|boolean Notify on success

--- a/lua/resession/layout.lua
+++ b/lua/resession/layout.lua
@@ -162,7 +162,7 @@ end
 
 ---@param layout table
 ---@param scale_factor number[] Scaling factor for [width, height]
----@return nil|integer The window that should have focus after session load
+---@return integer? The window that should have focus after session load
 M.set_winlayout = function(layout, scale_factor)
   if not layout then
     return

--- a/lua/resession/util.lua
+++ b/lua/resession/util.lua
@@ -13,7 +13,7 @@ local function get_option_scope(opt)
 end
 
 ---@param name string
----@return nil|resession.Extension
+---@return resession.Extension?
 M.get_extension = function(name)
   local has_ext, ext = pcall(require, string.format("resession.extensions.%s", name))
   if has_ext then


### PR DESCRIPTION
This does a couple things:

1. It fixes the doc strings for `save_tab` and `delete` where the `name` parameter is optional
2. Rather than using `nil|` we can define optional parameters a bit more semantically explicit by using `?`

Point number 2 is a bit of a stylistic choice and using some of the LSP specific semantics to communicate the parameter is optional rather than "can be `nil`". I can definitely revert that change if you prefer and just add `nil|string` for the two doc strings that were incomplete.


Thanks for all your work on this plugin and your others! They are truly magnificent ❤️ 