### PR TITLE
fix: cwd not set upon loading first buffer

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -438,18 +438,18 @@ M.load = function(name, opts)
   -- Ignore all messages (including swapfile messages) during session load
   local shortmess = vim.o.shortmess
   vim.o.shortmess = "aAF"
-  if not data.tab_scoped then
-    -- Set the options immediately
-    util.restore_global_options(data.global.options)
-    vim.cmd(string.format("cd %s", data.global.cwd))
-  end
   local scale = {
     vim.o.columns / data.global.width,
     (vim.o.lines - vim.o.cmdheight) / data.global.height,
   }
-  for _, buf in ipairs(data.buffers) do
+  for i, buf in ipairs(data.buffers) do
     local bufnr = vim.fn.bufadd(buf.name)
     if buf.loaded then
+      -- Set global options before loading the first buffer
+      if i == 1 and not data.tab_scoped then
+        util.restore_global_options(data.global.options)
+        vim.api.nvim_set_current_dir(data.global.cwd)
+      end
       vim.fn.bufload(bufnr)
       vim.b[bufnr]._resession_need_edit = true
       vim.api.nvim_create_autocmd("BufEnter", {

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -438,18 +438,18 @@ M.load = function(name, opts)
   -- Ignore all messages (including swapfile messages) during session load
   local shortmess = vim.o.shortmess
   vim.o.shortmess = "aAF"
+  if not data.tab_scoped then
+    -- Set the options immediately
+    util.restore_global_options(data.global.options)
+    vim.cmd(string.format("cd %s", data.global.cwd))
+  end
   local scale = {
     vim.o.columns / data.global.width,
     (vim.o.lines - vim.o.cmdheight) / data.global.height,
   }
-  for i, buf in ipairs(data.buffers) do
+  for _, buf in ipairs(data.buffers) do
     local bufnr = vim.fn.bufadd(buf.name)
     if buf.loaded then
-      -- Set global options before loading the first buffer
-      if i == 1 and not data.tab_scoped then
-        util.restore_global_options(data.global.options)
-        vim.api.nvim_set_current_dir(data.global.cwd)
-      end
       vim.fn.bufload(bufnr)
       vim.b[bufnr]._resession_need_edit = true
       vim.api.nvim_create_autocmd("BufEnter", {

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -489,6 +489,12 @@ M.load = function(name, opts)
       util.restore_tab_options(tab.options)
     end
   end
+
+  -- Ensure the cwd is set correctly for each loaded buffer
+  if not data.tab_scoped then
+    vim.api.nvim_set_current_dir(data.global.cwd)
+  end
+
   -- This can be nil if we saved a session in a window with an unsupported buffer
   if curwin then
     vim.api.nvim_set_current_win(curwin)


### PR DESCRIPTION
**Problem**: Normally, `<c-g>` and `:w` will output a message with the current buffer's filename relative the the cwd. However, when the buffer is restored from a session, the message (as well as the default statusline) show the filename relative the home directory instead. This doesn't seem to happen in tab-scoped sessions where each tab has its own cwd. 

Before saving session  (cwd set to `~/Documents`):
<img width="880" alt="image" src="https://github.com/stevearc/resession.nvim/assets/56745535/d30f6618-f0fa-4cd9-8986-bc1b495fd885">

After restoring session:
<img width="880" alt="image" src="https://github.com/stevearc/resession.nvim/assets/56745535/9dc8c345-749e-44a3-b75a-799ad498809f">

In the "after" screenshot, the cwd is set correctly, but the filename is displayed as if it were set to the home directory.

**Solution**: This PR resolves the issue by setting global options upon loading the first buffer. It also uses the lua api to set the cwd instead of `vim.cmd`.
