### PR TITLE
feat: allow consecutive deletion of sessions

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -138,6 +138,7 @@ M.delete = function(name, opts)
       function(selected)
         if selected then
           M.delete(selected)
+          M.delete()
         end
       end
     )


### PR DESCRIPTION
More often than not, a user will want to delete multiple sessions simultaneously (in my experience). For these situations, it makes sense to prompt the user again after sucessfully deleting a session, rather than having them repeatedly call the delete function.

**Other ideas**:
Maybe there's a way to leverage telescope's multiselect and delete all of them simultaneously, or an optional argument could be passed in enable the repeated deletion prompt, though both of these would add complexity to the api and implementation. 