### PR TITLE
fix: don't load plugin if extension data is empty

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -503,7 +503,7 @@ M.load = function(name, opts)
   end
 
   for ext_name in pairs(config.extensions) do
-    if data[ext_name] then
+    if data[ext_name] and not vim.tbl_isempty(data[ext_name]) then
       local ext = util.get_extension(ext_name)
       if ext then
         local ok, err = pcall(ext.on_load, data[ext_name])


### PR DESCRIPTION
I have the overseer extension enabled, and it was causing overseer to alway loading on startup, adding about 100ms to startup time even when there were no tasks set for the current session. 

This prevents any plugin associated with the extension from loading if the data is empty.