### PR TITLE
fix(quickfix): wait until it is safe to open the quickfix list

### DIFF
--- a/lua/resession/extensions/quickfix.lua
+++ b/lua/resession/extensions/quickfix.lua
@@ -20,9 +20,7 @@ M.on_save = function()
 end
 
 M.on_load = function(data)
-  vim.defer_fn(function()
-    vim.fn.setqflist(data)
-  end, 0)
+  vim.fn.setqflist(data)
 end
 
 M.is_win_supported = function(winid, bufnr)
@@ -35,7 +33,9 @@ end
 
 M.load_win = function(winid, config)
   vim.api.nvim_set_current_win(winid)
-  vim.cmd("copen")
+  vim.defer_fn(function()
+    vim.cmd("copen")
+  end, 0)
   vim.api.nvim_win_close(winid, true)
   return vim.api.nvim_get_current_win()
 end

--- a/lua/resession/extensions/quickfix.lua
+++ b/lua/resession/extensions/quickfix.lua
@@ -20,7 +20,9 @@ M.on_save = function()
 end
 
 M.on_load = function(data)
-  vim.fn.setqflist(data)
+  vim.defer_fn(function()
+    vim.fn.setqflist(data)
+  end, 0)
 end
 
 M.is_win_supported = function(winid, bufnr)


### PR DESCRIPTION
I'm not sure why this might be the case, but it seems like nvim-bqf completely breaks in the first qf window restored by resession quickfix extension on startup.

Either deferring the callback of `:copen` or `setqflist()` resolves this, but the former seems to have the added benefit of properly restoring the quickfix list if the cursor was last in the qf window upon last saving the session (an entirely separate issue btw). Unfortunately, this also means that if the cursor was not previously in the qf window, then it is incorrectly set to the qf window upon restoring the session.

This is a rough proposal, do let me know if you have any better ideas.