### PR TITLE
feat!: `get_current()` returns custom session save directory if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,14 +367,14 @@ Load an extension some time after calling setup()
 ### get_current()
 
 `get_current(): string` \
-Get the name of the current session
+Get the name of the current session and the save directory, if available
 
 
 Returns:
 
-| Type   | Desc |
-| ------ | ---- |
-| string | ?    |
+| Type   | Desc       |
+| ------ | ---------- |
+| string | ?, string? |
 
 ### detach()
 

--- a/README.md
+++ b/README.md
@@ -367,14 +367,14 @@ Load an extension some time after calling setup()
 ### get_current()
 
 `get_current(): string` \
-Get the name of the current session and the save directory, if available
+Get the name of the current session
 
 
 Returns:
 
-| Type   | Desc       |
-| ------ | ---------- |
-| string | ?, string? |
+| Type   | Desc |
+| ------ | ---- |
+| string | ?    |
 
 ### detach()
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A replacement for `:mksession` with a better API
   - [setup(config)](#setupconfig)
   - [load_extension(name, opts)](#load_extensionname-opts)
   - [get_current()](#get_current)
+  - [get_current_session_info()](#get_current_session_info)
   - [detach()](#detach)
   - [list(opts)](#listopts)
   - [delete(name, opts)](#deletename-opts)
@@ -375,6 +376,12 @@ Returns:
 | Type   | Desc |
 | ------ | ---- |
 | string | ?    |
+
+### get_current_session_info()
+
+`get_current_session_info(): resession.SessionInfo` \
+Get information about the current session
+
 
 ### detach()
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Returns:
 
 ### get_current_session_info()
 
-`get_current_session_info(): resession.SessionInfo` \
+`get_current_session_info(): nil|resession.SessionInfo` \
 Get information about the current session
 
 

--- a/doc/resession.txt
+++ b/doc/resession.txt
@@ -76,7 +76,7 @@ get_current(): string                                      *resession.get_curren
     Returns:
       `string` ?
 
-get_current_session_info(): resession.SessionInfo *resession.get_current_session_info*
+get_current_session_info(): nil|resession.SessionInfo *resession.get_current_session_info*
     Get information about the current session
 
 

--- a/doc/resession.txt
+++ b/doc/resession.txt
@@ -71,10 +71,10 @@ load_extension({name}, {opts})                          *resession.load_extensio
       {opts} `table` Configuration options for extension
 
 get_current(): string                                      *resession.get_current*
-    Get the name of the current session
+    Get the name of the current session and the save directory, if available
 
     Returns:
-      `string` ?
+      `string` ?, string?
 
 detach()                                                        *resession.detach*
     Detach from the current session

--- a/doc/resession.txt
+++ b/doc/resession.txt
@@ -71,10 +71,10 @@ load_extension({name}, {opts})                          *resession.load_extensio
       {opts} `table` Configuration options for extension
 
 get_current(): string                                      *resession.get_current*
-    Get the name of the current session and the save directory, if available
+    Get the name of the current session
 
     Returns:
-      `string` ?, string?
+      `string` ?
 
 detach()                                                        *resession.detach*
     Detach from the current session

--- a/doc/resession.txt
+++ b/doc/resession.txt
@@ -76,6 +76,10 @@ get_current(): string                                      *resession.get_curren
     Returns:
       `string` ?
 
+get_current_session_info(): resession.SessionInfo *resession.get_current_session_info*
+    Get information about the current session
+
+
 detach()                                                        *resession.detach*
     Detach from the current session
 

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -67,10 +67,7 @@ end
 M.get_current = function()
   local tabpage = vim.api.nvim_get_current_tabpage()
   local session = tab_sessions[tabpage] or current_session
-  if session_configs[session] ~= nil then
-    return session, session_configs[session].dir
-  end
-  return session
+  return session, session_configs[session] and session_configs[session].dir
 end
 
 ---Detach from the current session

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -62,12 +62,11 @@ M.load_extension = function(name, opts)
   end
 end
 
----Get the name of the current session and the save directory, if available
----@return string?, string?
+---Get the name of the current session
+---@return string?
 M.get_current = function()
   local tabpage = vim.api.nvim_get_current_tabpage()
-  local session = tab_sessions[tabpage] or current_session
-  return session, session_configs[session] and session_configs[session].dir
+  return tab_sessions[tabpage] or current_session
 end
 
 ---Detach from the current session

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -69,6 +69,17 @@ M.get_current = function()
   return tab_sessions[tabpage] or current_session
 end
 
+---Get information about the current session
+---@return resession.SessionInfo
+M.get_current_session_info = function()
+  local session_info = {}
+  local session = M.get_current()
+  if session_info[session] ~= nil then
+    session_info.dir = session_info[session].dir
+  end
+  return session_info
+end
+
 ---Detach from the current session
 M.detach = function()
   current_session = nil

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -76,7 +76,7 @@ M.get_current_session_info = function()
   if not session then
     return nil
   end
-  local save_dir = session_configs[session].dir
+  local save_dir = require("resession.util").get_session_dir(session_configs[session].dir)
   return { name = session, dir = save_dir }
 end
 
@@ -269,7 +269,7 @@ local function save(name, opts, target_tabpage)
   end
   if opts.attach then
     session_configs[name] = {
-      dir = opts.dir,
+      dir = opts.dir or config.dir,
     }
   end
   vim.o.eventignore = eventignore
@@ -562,7 +562,7 @@ M.load = function(name, opts)
       current_session = name
     end
     session_configs[name] = {
-      dir = opts.dir,
+      dir = opts.dir or config.dir,
     }
   end
   vim.o.eventignore = eventignore

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -62,7 +62,7 @@ M.load_extension = function(name, opts)
   end
 end
 
----Get the name of the current session
+---Get the name of the current session and the save directory, if available
 ---@return string?, string?
 M.get_current = function()
   local tabpage = vim.api.nvim_get_current_tabpage()

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -70,14 +70,14 @@ M.get_current = function()
 end
 
 ---Get information about the current session
----@return resession.SessionInfo
+---@return nil|resession.SessionInfo
 M.get_current_session_info = function()
-  local session_info = {}
   local session = M.get_current()
-  if session_info[session] ~= nil then
-    session_info.dir = session_info[session].dir
+  if not session then
+    return nil
   end
-  return session_info
+  local save_dir = session_configs[session].dir
+  return { name = session, dir = save_dir }
 end
 
 ---Detach from the current session

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -63,10 +63,14 @@ M.load_extension = function(name, opts)
 end
 
 ---Get the name of the current session
----@return string?
+---@return string?, string?
 M.get_current = function()
   local tabpage = vim.api.nvim_get_current_tabpage()
-  return tab_sessions[tabpage] or current_session
+  local session = tab_sessions[tabpage] or current_session
+  if session_configs[session] ~= nil then
+    return session, session_configs[session].dir
+  end
+  return session
 end
 
 ---Detach from the current session

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -76,7 +76,7 @@ M.get_current_session_info = function()
   if not session then
     return nil
   end
-  local save_dir = require("resession.util").get_session_dir(session_configs[session].dir)
+  local save_dir = session_configs[session].dir
   return { name = session, dir = save_dir }
 end
 

--- a/lua/resession/types.lua
+++ b/lua/resession/types.lua
@@ -1,6 +1,5 @@
 ---@class resession.ListOpts
 ---@field dir nil|string Name of directory to save to (overrides config.dir)
----
 
 ---@class resession.DeleteOpts
 ---@field dir nil|string Name of directory to save to (overrides config.dir)
@@ -23,3 +22,7 @@
 ---@field is_win_supported nil|fun(winid: integer, bufnr: integer): boolean
 ---@field save_win nil|fun(winid: integer): any
 ---@field load_win nil|fun(winid: integer, data: any): nil|integer
+
+---@class resession.SessionInfo
+---@field name nil|string Name of the current session
+---@field directory nil|string Name of the directory that the current session is saved in

--- a/lua/resession/types.lua
+++ b/lua/resession/types.lua
@@ -25,4 +25,4 @@
 
 ---@class resession.SessionInfo
 ---@field name string Name of the current session
----@field directory string Name of the directory that the current session is saved in
+---@field dir string Name of the directory that the current session is saved in

--- a/lua/resession/types.lua
+++ b/lua/resession/types.lua
@@ -24,5 +24,5 @@
 ---@field load_win nil|fun(winid: integer, data: any): nil|integer
 
 ---@class resession.SessionInfo
----@field name nil|string Name of the current session
----@field directory nil|string Name of the directory that the current session is saved in
+---@field name string Name of the current session
+---@field directory string Name of the directory that the current session is saved in


### PR DESCRIPTION
Currently, there is no easy way (afaik) to retrieve session data for sessions not stored in the default save directory from within the session itself. It would be nice if the API exposed a function to do exactly that. One fairly clean way of doing this might be to add this functionality to the existing `get_current()`, by allowing it to have a second optional return string representing the save directory. This way, data for the current session can be retrieved (no matter the save directory) like this:

```lua
local resession = require "resession"
local files = require "resession.files"
local util = require "resession.util"

local filename = util.get_session_file(resession.get_current())
local data = files.load_json_file(filename)
```

If you're wondering what my use case is, I would like to have my [Grapple](https://github.com/cbochs/grapple.nvim) tags specific to a session, and one way to do this by having a custom resolver that creates a scope based on the cwd of the current session. (Since `projects.nvim` autochanges the directory, it's necessary to have the scope resolved to global cwd stored by `resession.nvim` as opposed to the vim's cwd so that the tags don't get reset). This allows Grapple's builtin resession extension to function seamlessly in this kind of workflow.

<details>
<summary>Example Grapple setup</summary>

```lua
local scope = require "grapple.scope"
local resession = require "resession"
local files = require "resession.files"
local util = require "resession.util"

local get_session_path = function(session_name, dirname)
  if session_name then
    local filename = util.get_session_file(session_name, dirname)
    local data = files.load_json_file(filename)
    if data then
      local session_cwd = data.tab_scoped and data.tabs[1].cwd or data.global.cwd
      return string.format("%s", session_cwd)
    end
  end
end

local session_path = scope.resolver(function()
  if resession.get_current() then return string.format("%s", get_session_path(resession.get_current())) end
end, { cache = false, persist = false })

local resolver = scope.fallback {
  session_path,
  require("grapple.scope_resolvers").git,
}

local format_title = function()
  local current_session, session_dir = resession.get_current()
  if current_session then
    local title = string.format(" %s [%s] ", current_session, util.shorten_path(get_session_path(current_session, session_dir)))
    return #title > 50 and string.format(" %s ", current_session) or title
  else
    local git_root = require("grapple.state").ensure_loaded(require("grapple.scope_resolvers").git)
    return string.format(" %s ", git_root ~= vim.env.HOME and util.shorten_path(git_root) or git_root)
  end
end

resession.add_hook("pre_save", function()
  if require("resession").get_current() == nil then
    require("grapple").save()
    require("grapple.settings").integrations.resession = true
  end
end)
resession.add_hook("pre_load", function()
  require("grapple").save()
  require("grapple.settings").integrations.resession = true
end)

local unload_scopes = function()
  local grapple_state = require("grapple.state").state()
  for loaded_scope, _ in pairs(grapple_state) do
    if loaded_scope ~= get_session_path(resession.get_current()) then require("grapple.state").reset(loaded_scope, true) end
  end
end
resession.add_hook("post_save", function() unload_scopes() end)
resession.add_hook("post_load", function() unload_scopes() end)

```

</details>