### PR TITLE
fix: reverse window layout recreation

### DIFF
--- a/lua/resession/layout.lua
+++ b/lua/resession/layout.lua
@@ -92,7 +92,7 @@ local function set_winlayout(layout)
     local splitright = vim.opt.splitright
     local splitbelow = vim.opt.splitbelow
     vim.opt.splitright = true
-    vim.opt.splitbottom = true
+    vim.opt.splitbelow = true
     for i in ipairs(layout[2]) do
       if i > 1 then
         if type == "row" then

--- a/lua/resession/layout.lua
+++ b/lua/resession/layout.lua
@@ -89,6 +89,10 @@ local function set_winlayout(layout)
     end
   else
     local winids = {}
+    local splitright = vim.opt.splitright
+    local splitbelow = vim.opt.splitbelow
+    vim.opt.splitright = true
+    vim.opt.splitbottom = true
     for i in ipairs(layout[2]) do
       if i > 1 then
         if type == "row" then
@@ -99,6 +103,8 @@ local function set_winlayout(layout)
       end
       table.insert(winids, vim.api.nvim_get_current_win())
     end
+    vim.opt.splitright = splitright
+    vim.opt.splitbelow = splitbelow
     for i, v in ipairs(layout[2]) do
       vim.api.nvim_set_current_win(winids[i])
       set_winlayout(v)


### PR DESCRIPTION
This PR fixes #34

The order in which windows are inserted when loading layouts has been corrected. In order not to override user preference for split directions, these are buffered and restored after insertion.