### PR TITLE
fix: floating window lead causes no problems

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -405,6 +405,12 @@ local function close_everything()
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end
   end
+
+  -- make sure, we are working with a none-floating window
+  local winid = vim.api.nvim_get_current_win()
+  vim.cmd("vsplit")
+  vim.api.nvim_win_close(winid, true)
+
   vim.cmd("silent! tabonly")
   vim.cmd("silent! only")
 end

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -407,6 +407,7 @@ local function close_everything()
   end
 
   -- make sure, we are working with a none-floating window
+  -- make sure, we are working with a non-floating window
   local winid = vim.api.nvim_get_current_win()
   vim.cmd("vsplit")
   vim.api.nvim_win_close(winid, true)

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -406,7 +406,6 @@ local function close_everything()
     end
   end
 
-  -- make sure, we are working with a none-floating window
   -- make sure, we are working with a non-floating window
   local winid = vim.api.nvim_get_current_win()
   vim.cmd("vsplit")


### PR DESCRIPTION
This PR is to be primarily understood as a suggestion for solving issue #37.

It aims at making loading a session in presence of a floating windows more robust by additionally closing the last window left over from the current session after splitting a fresh one off of it in _init.lua_s `close_everything`'s function. This gives a clean slate to load the desired session from.