### PR TITLE
docs: correct wording and typo in API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,21 +400,21 @@ Detach from the current session
 `list(opts): string[]` \
 List all available saved sessions
 
-| Param | Type                      | Desc          |                                                     |
-| ----- | ------------------------- | ------------- | --------------------------------------------------- |
-| opts  | `nil\|resession.ListOpts` |               |                                                     |
-|       | dir                       | `nil\|string` | Name of directory to save to (overrides config.dir) |
+| Param | Type                      | Desc          |                                                  |
+| ----- | ------------------------- | ------------- | ------------------------------------------------ |
+| opts  | `nil\|resession.ListOpts` |               |                                                  |
+|       | dir                       | `nil\|string` | Name of directory to list (overrides config.dir) |
 
 ### delete(name, opts)
 
 `delete(name, opts)` \
 Delete a saved session
 
-| Param | Type                        | Desc                                          |                                                     |
-| ----- | --------------------------- | --------------------------------------------- | --------------------------------------------------- |
-| name  | `nil\|string`               | If not provided, prompt for session to delete |                                                     |
-| opts  | `nil\|resession.DeleteOpts` |                                               |                                                     |
-|       | dir                         | `nil\|string`                                 | Name of directory to save to (overrides config.dir) |
+| Param | Type                        | Desc                                          |                                                         |
+| ----- | --------------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| name  | `nil\|string`               | If not provided, prompt for session to delete |                                                         |
+| opts  | `nil\|resession.DeleteOpts` |                                               |                                                         |
+|       | dir                         | `nil\|string`                                 | Name of directory to delete from (overrides config.dir) |
 
 ### save(name, opts)
 
@@ -457,14 +457,14 @@ Save all current sessions to disk
 `load(name, opts)` \
 Load a session
 
-| Param | Type                      | Desc                   |                                                             |
-| ----- | ------------------------- | ---------------------- | ----------------------------------------------------------- |
-| name  | `nil\|string`             |                        |                                                             |
-| opts  | `nil\|resession.LoadOpts` |                        |                                                             |
-|       | attach                    | `nil\|boolean`         | Stay attached to session after loading (default true)       |
-|       | reset                     | `nil\|boolean\|"auto"` | Close everthing before loading the session (default "auto") |
-|       | silence_errors            | `nil\|boolean`         | Don't error when trying to load a missing session           |
-|       | dir                       | `nil\|string`          | Name of directory to load from (overrides config.dir)       |
+| Param | Type                      | Desc                   |                                                              |
+| ----- | ------------------------- | ---------------------- | ------------------------------------------------------------ |
+| name  | `nil\|string`             |                        |                                                              |
+| opts  | `nil\|resession.LoadOpts` |                        |                                                              |
+|       | attach                    | `nil\|boolean`         | Stay attached to session after loading (default true)        |
+|       | reset                     | `nil\|boolean\|"auto"` | Close everything before loading the session (default "auto") |
+|       | silence_errors            | `nil\|boolean`         | Don't error when trying to load a missing session            |
+|       | dir                       | `nil\|string`          | Name of directory to load from (overrides config.dir)        |
 
 **Note:**
 <pre>

--- a/doc/resession.txt
+++ b/doc/resession.txt
@@ -89,7 +89,7 @@ list({opts}): string[]                                            *resession.lis
 
     Parameters:
       {opts} `nil|resession.ListOpts`
-          {dir} `nil|string` Name of directory to save to (overrides config.dir)
+          {dir} `nil|string` Name of directory to list (overrides config.dir)
 
 delete({name}, {opts})                                          *resession.delete*
     Delete a saved session
@@ -97,7 +97,8 @@ delete({name}, {opts})                                          *resession.delet
     Parameters:
       {name} `nil|string` If not provided, prompt for session to delete
       {opts} `nil|resession.DeleteOpts`
-          {dir} `nil|string` Name of directory to save to (overrides config.dir)
+          {dir} `nil|string` Name of directory to delete from (overrides
+                config.dir)
 
 save({name}, {opts})                                              *resession.save*
     Save a session to disk
@@ -138,7 +139,7 @@ load({name}, {opts})                                              *resession.loa
       {opts} `nil|resession.LoadOpts`
           {attach}         `nil|boolean` Stay attached to session after loading
                            (default true)
-          {reset}          `nil|boolean|"auto"` Close everthing before loading
+          {reset}          `nil|boolean|"auto"` Close everything before loading
                            the session (default "auto")
           {silence_errors} `nil|boolean` Don't error when trying to load a
                            missing session

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -103,7 +103,7 @@ end
 
 ---List all available saved sessions
 ---@param opts? resession.ListOpts
----    dir? string Name of directory to save to (overrides config.dir)
+---    dir? string Name of directory to list (overrides config.dir)
 ---@return string[]
 M.list = function(opts)
   opts = opts or {}
@@ -168,7 +168,7 @@ end
 ---Delete a saved session
 ---@param name? string If not provided, prompt for session to delete
 ---@param opts? resession.DeleteOpts
----    dir? string Name of directory to save to (overrides config.dir)
+---    dir? string Name of directory to delete from (overrides config.dir)
 M.delete = function(name, opts)
   opts = opts or {}
   local files = require("resession.files")
@@ -419,7 +419,7 @@ local _is_loading = false
 ---@param name? string
 ---@param opts? resession.LoadOpts
 ---    attach? boolean Stay attached to session after loading (default true)
----    reset? boolean|"auto" Close everthing before loading the session (default "auto")
+---    reset? boolean|"auto" Close everything before loading the session (default "auto")
 ---    silence_errors? boolean Don't error when trying to load a missing session
 ---    dir? string Name of directory to load from (overrides config.dir)
 ---@note

--- a/lua/resession/types.lua
+++ b/lua/resession/types.lua
@@ -1,8 +1,8 @@
 ---@class (exact) resession.ListOpts
----@field dir? string Name of directory to save to (overrides config.dir)
+---@field dir? string Name of directory to list (overrides config.dir)
 
 ---@class (exact) resession.DeleteOpts
----@field dir? string Name of directory to save to (overrides config.dir)
+---@field dir? string Name of directory to delete from (overrides config.dir)
 
 ---@class (exact) resession.SaveOpts
 ---@field attach? boolean Stay attached to session after saving
@@ -11,7 +11,7 @@
 
 ---@class (exact) resession.LoadOpts
 ---@field attach? boolean Attach to session after loading
----@field reset? boolean|"auto" Close everthing before loading the session (default "auto")
+---@field reset? boolean|"auto" Close everything before loading the session (default "auto")
 ---@field silence_errors? boolean Don't error when trying to load a missing session
 ---@field dir? string Name of directory to load from (overrides config.dir)
 


### PR DESCRIPTION
While trying to wrap _resession_ in my Neovim config, i noticed the `load` function of the API does not list the files in the directory i was giving it via `opts.dir`. A quick look into the source revealed it ignores/omits `opts` completely when calling `M.list`.

Same goes for `delete`.

I fixed some wording issues while being at it. I hope that okay. If not, i'm happy to open a separate PR.
