### PR TITLE
fix: use the provided dir in `resession.load()` and `resession.delete()`

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -174,7 +174,7 @@ M.delete = function(name, opts)
   local files = require("resession.files")
   local util = require("resession.util")
   if not name then
-    local sessions = M.list()
+    local sessions = M.list({ dir = opts.dir })
     if vim.tbl_isempty(sessions) then
       vim.notify("No saved sessions", vim.log.levels.WARN)
       return
@@ -184,7 +184,7 @@ M.delete = function(name, opts)
       { kind = "resession_delete", prompt = "Delete session" },
       function(selected)
         if selected then
-          M.delete(selected)
+          M.delete(selected, { dir = opts.dir })
         end
       end
     )
@@ -435,7 +435,7 @@ M.load = function(name, opts)
   local layout = require("resession.layout")
   local util = require("resession.util")
   if not name then
-    local sessions = M.list()
+    local sessions = M.list({ dir = opts.dir })
     if vim.tbl_isempty(sessions) then
       vim.notify("No saved sessions", vim.log.levels.WARN)
       return


### PR DESCRIPTION
`load` and `delete` currently ignore the dir provided in options, only listing sessions from the main session directory. This PR passes the dir to `list` so that the correct dir is used if it is passed in the opts dict.