### PR TITLE
feat: pass `target_tabpage` to `ext.on_save`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ To create an extension, create a file in your runtimepath at `lua/resession/exte
 local M = {}
 
 ---Get the saved data for this extension
+---@param opts resession.Extension.OnSaveOpts Information about the session being saved
 ---@return any
-M.on_save = function()
+M.on_save = function(opts)
   return {}
 end
 

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -265,7 +265,9 @@ local function save(name, opts, target_tabpage)
   for ext_name, ext_config in pairs(config.extensions) do
     local ext = util.get_extension(ext_name)
     if ext and ext.on_save and (ext_config.enable_in_tab or not target_tabpage) then
-      local ok, ext_data = pcall(ext.on_save)
+      local ok, ext_data = pcall(ext.on_save, {
+        tabpage = target_tabpage,
+      })
       if ok then
         data[ext_name] = ext_data
       else

--- a/lua/resession/types.lua
+++ b/lua/resession/types.lua
@@ -15,8 +15,11 @@
 ---@field silence_errors? boolean Don't error when trying to load a missing session
 ---@field dir? string Name of directory to load from (overrides config.dir)
 
+---@class (exact) resession.Extension.OnSaveOpts
+---@field tabpage integer? The tabpage being saved, if in a tab-scoped session
+
 ---@class (exact) resession.Extension
----@field on_save? fun():any
+---@field on_save? fun(opts: resession.Extension.OnSaveOpts):any
 ---@field on_pre_load? fun(data: any)
 ---@field on_post_load? fun(data: any)
 ---@field config? fun(options: table)


### PR DESCRIPTION
Allows extensions to determine if the session being saved is tab-scoped, and if so which tabpage the extension should save.

Preemptively takes care of the issue I mentioned [here](https://github.com/stevearc/resession.nvim/issues/40#issuecomment-1749964710).