### PR TITLE
fix: set buftype='' instead of 'nofile' for empty initial buffer

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -411,6 +411,7 @@ local function close_everything()
   local scratch = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_option(scratch, "bufhidden", "wipe")
   vim.api.nvim_win_set_buf(0, scratch)
+  vim.api.nvim_buf_set_option(scratch, "buftype", "")
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.bo[bufnr].buflisted then
       vim.api.nvim_buf_delete(bufnr, { force = true })


### PR DESCRIPTION
Fixes a big with `flatten.nvim`'s smart open, but also, the initial window open in `nvim --clean` has `buftype=''` so I think this should be how it works anyways.