### PR TITLE
docs: fix suggested VimEnter autocmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ vim.api.nvim_create_autocmd("VimEnter", {
       resession.load(vim.fn.getcwd(), { dir = "dirsession", silence_errors = true })
     end
   end,
-  -- Needed to allow autocmds to trigger when loading files (#44)
   nested = true,
 })
 vim.api.nvim_create_autocmd("VimLeavePre", {

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ vim.api.nvim_create_autocmd("VimEnter", {
       resession.load(vim.fn.getcwd(), { dir = "dirsession", silence_errors = true })
     end
   end,
+  -- Needed to allow autocmds to trigger when loading files (#44)
+  nested = true,
 })
 vim.api.nvim_create_autocmd("VimLeavePre", {
   callback = function()


### PR DESCRIPTION
Adds `nested = true` to the suggested VimEnter autocmd, as per https://github.com/stevearc/resession.nvim/issues/44#issuecomment-2027345600.

Fixes #44