### PR TITLE
fix: colon appearing in filepath for windows OS dirsession

### DIFF
--- a/lua/resession/util.lua
+++ b/lua/resession/util.lua
@@ -141,7 +141,7 @@ end
 ---@return string
 M.get_session_file = function(name, dirname)
   local files = require("resession.files")
-  local filename = string.format("%s.json", name:gsub(files.sep, "_"))
+  local filename = string.format("%s.json", name:gsub(files.sep, "_"):gsub(":", "_"))
   return files.join(M.get_session_dir(dirname), filename)
 end
 


### PR DESCRIPTION
In windows OS, saving dirsession with `resession.save(vim.fn.getcwd(), { dir = "dirsession", notify = false })` doesn't work.

`vim.fn.getcwd()` includes the drive name in front, e.g. `C:\path\to\cwd`, which is not handled by `get_session_file()`, causing it to return faulty json file path like `C:\nvim-data\dirsession\C:_path_to_cwd.json`.

This fix does another gsub to replace `:` with `_`. If there's a better way to do it, let me know.

Thanks!