### PR TITLE
fix: restore window cursor pos after setting size

### DIFF
--- a/lua/resession/layout.lua
+++ b/lua/resession/layout.lua
@@ -151,12 +151,12 @@ local function set_winlayout_data(layout, scale_factor, visit_data)
       vim.o.eventignore = "all"
       vim.b[bufnr].resession_restore_last_pos = nil
     end
-    pcall(vim.api.nvim_win_set_cursor, win.winid, win.cursor)
     util.restore_win_options(win.winid, win.options)
     local width_scale = vim.wo.winfixwidth and 1 or scale_factor[1]
     vim.api.nvim_win_set_width(win.winid, scale(win.width, width_scale))
     local height_scale = vim.wo.winfixheight and 1 or scale_factor[2]
     vim.api.nvim_win_set_height(win.winid, scale(win.height, height_scale))
+    pcall(vim.api.nvim_win_set_cursor, win.winid, win.cursor)
     if win.current then
       visit_data.winid = win.winid
     end


### PR DESCRIPTION
This fixes an issue I was running into where the cursor position of open buffers would not get restored properly.

The easiest way to reproduce is to open a file where the length of the file is at least a couple times longer than the window height. Then scroll down all the way to the bottom, create/save a session, and exit Neovim. If you then reopen Neovim and load the session, you should see that the cursor is in the wrong place (for me, it always is at line 45).

Edit: this is happening because I've set `splitkeep=screen` (because I'm using https://github.com/folke/edgy.nvim) - setting it back to the default `splitkeep=cursor` also fixes the issue. A more complicated fix would be to temporarily set `splitkeep=cursor` while loading the window layout, but just reordering the operations achieves the same thing and is simpler.