### PR TITLE
docs: add link to telescope extension in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ Returns true if a session is currently being loaded
 - [quickfix](lua/resession/extensions/quickfix.lua) (built-in)
 - [aerial.nvim](https://github.com/stevearc/aerial.nvim)
 - [overseer.nvim](https://github.com/stevearc/overseer.nvim)
+- [telescope-resession.nvim](https://github.com/scottmckendry/telescope-resession.nvim)
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Returns true if a session is currently being loaded
 - [quickfix](lua/resession/extensions/quickfix.lua) (built-in)
 - [aerial.nvim](https://github.com/stevearc/aerial.nvim)
 - [overseer.nvim](https://github.com/stevearc/overseer.nvim)
-- [telescope-resession.nvim](https://github.com/scottmckendry/telescope-resession.nvim)
+- [telescope-resession.nvim](https://github.com/scottmckendry/telescope-resession.nvim) - alternative save/load UI
 
 ## FAQ
 


### PR DESCRIPTION
I've developed a telescope extension that adds a telescope picker for resession.nvim sessions. 

https://github.com/scottmckendry/telescope-resession.nvim

This makes a great addition to the plugin as it allows users to quickly jump between sessions without too much thought. 