### PR TITLE
feat: Add `notify` opts for deleting a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Delete a saved session
 | name  | `nil\|string`               | If not provided, prompt for session to delete |                                                         |
 | opts  | `nil\|resession.DeleteOpts` |                                               |                                                         |
 |       | dir                         | `nil\|string`                                 | Name of directory to delete from (overrides config.dir) |
+|       | notify                      | `nil\|boolean`                                | Notify on success (default true)                        |
 
 ### save(name, opts)
 
@@ -432,7 +433,7 @@ Save a session to disk
 | name  | `nil\|string`             |                |                                                      |
 | opts  | `nil\|resession.SaveOpts` |                |                                                      |
 |       | attach                    | `nil\|boolean` | Stay attached to session after saving (default true) |
-|       | notify                    | `nil\|boolean` | Notify on success                                    |
+|       | notify                    | `nil\|boolean` | Notify on success (default true)                     |
 |       | dir                       | `nil\|string`  | Name of directory to save to (overrides config.dir)  |
 
 ### save_tab(name, opts)

--- a/lua/resession/files.lua
+++ b/lua/resession/files.lua
@@ -104,8 +104,7 @@ end
 ---@param filename string
 M.delete_file = function(filename)
   if M.exists(filename) then
-    uv.fs_unlink(filename)
-    return true
+    return (uv.fs_unlink(filename))
   end
 end
 

--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -172,7 +172,9 @@ end
 ---@param name? string If not provided, prompt for session to delete
 ---@param opts? resession.DeleteOpts
 M.delete = function(name, opts)
-  opts = opts or {}
+  opts = vim.tbl_extend("keep", opts or {}, {
+    notify = true,
+  })
   local files = require("resession.files")
   local util = require("resession.util")
   if not name then
@@ -193,7 +195,11 @@ M.delete = function(name, opts)
     return
   end
   local filename = util.get_session_file(name, opts.dir)
-  if not files.delete_file(filename) then
+  if files.delete_file(filename) then
+    if opts.notify then
+      vim.notify(string.format('Deleted session "%s"', name))
+    end
+  else
     error(string.format('No session "%s"', filename))
   end
   if current_session == name then

--- a/lua/resession/types.lua
+++ b/lua/resession/types.lua
@@ -3,10 +3,11 @@
 
 ---@class (exact) resession.DeleteOpts
 ---@field dir? string Name of directory to delete from (overrides config.dir)
+---@field notify? boolean Notify on success (default true)
 
 ---@class (exact) resession.SaveOpts
 ---@field attach? boolean Stay attached to session after saving (default true)
----@field notify? boolean Notify on success
+---@field notify? boolean Notify on success (default true)
 ---@field dir? string Name of directory to save to (overrides config.dir)
 
 ---@class (exact) resession.SaveAllOpts


### PR DESCRIPTION
It would be beneficial to include a notification when a session is successfully deleted. This would mirror the existing functionality for the `save` action by incorporating an optional boolean parameter named `notify` for the `delete` action. By default, this parameter is set to `true`, following the same logic used for the save action.

Also updated the README.md to show that the `notify` is by default `true` for the `save` action as well.