### PR TITLE
fix: fallback to last buffer if window empty (#66)

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -522,8 +522,12 @@ M.load = function(name, opts)
     vim.o.columns / data.global.width,
     (vim.o.lines - vim.o.cmdheight) / data.global.height,
   }
+
+  local last_bufnr
   for _, buf in ipairs(data.buffers) do
     local bufnr = vim.fn.bufadd(buf.name)
+    last_bufnr = bufnr
+
     if buf.loaded then
       vim.fn.bufload(bufnr)
       vim.b[bufnr]._resession_need_edit = true
@@ -574,9 +578,12 @@ M.load = function(name, opts)
     end
   end
 
-  -- This can be nil if we saved a session in a window with an unsupported buffer
+  -- curwin can be nil if we saved a session in a window with an unsupported buffer, in which case we will switch to
+  -- the last restored buffer.
   if curwin then
     vim.api.nvim_set_current_win(curwin)
+  elseif last_bufnr then
+    vim.cmd("buffer " .. last_bufnr)
   end
 
   for ext_name in pairs(config.extensions) do


### PR DESCRIPTION
If `curwin` is `nil` during session load (which can happen when the buffer in the only window was filtered out of the session), fall back to opening the last restored buffer. 

Currently, as described by #66, if the last buffer in the last window is something you're filtering out (by default or with a custom `buf_filter`, when you restore that session you get an empty window. With this change, you'll instead get the most-recently-restored buffer from the session.

This should only affect single-window, single-tab scenarios (the existing behavior in those scenarios, where the window containing the filtered-out buffer is simply not restored) should be preserved by this change. 

This isn't gated by an option because the current behavior felt like a bug to me, but it would be pretty easy to add a `fall_back_to_most_recent` option (maybe with a better name) if desired.
