### PR TITLE
fix: Exec BufRead and BufReadPre after load

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -621,6 +621,9 @@ M.load = function(name, opts)
   _is_loading = false
   dispatch("post_load", name, opts)
 
+  vim.api.nvim_exec_autocmds("BufReadPre", {})
+  vim.api.nvim_exec_autocmds("BufRead", {})
+
   -- In case the current buffer has a swapfile, make sure we trigger all the necessary autocmds
   vim.b._resession_need_edit = nil
   vim.cmd.edit({ mods = { emsg_silent = true } })

--- a/lua/resession/layout.lua
+++ b/lua/resession/layout.lua
@@ -145,10 +145,6 @@ local function set_winlayout_data(layout, scale_factor, visit_data)
     else
       local bufnr = vim.fn.bufadd(win.bufname)
       vim.api.nvim_win_set_buf(win.winid, bufnr)
-      -- After setting the buffer into the window, manually set the filetype to trigger syntax highlighting
-      vim.o.eventignore = ""
-      vim.bo[bufnr].filetype = vim.bo[bufnr].filetype
-      vim.o.eventignore = "all"
       vim.b[bufnr].resession_restore_last_pos = nil
     end
     util.restore_win_options(win.winid, win.options)


### PR DESCRIPTION
Fixes https://github.com/stevearc/resession.nvim/issues/69

The root cause of the issue is that when resession restores the old buffer, it does not trigger BufReadPre/BufRead/BufReadPost autocommands which many plugin features depend on (gitsigns, lsp, etc.). Manually triggering these events with `nvim_exec_autocmds` fixes the issue.

Autocommands triggered before the fix when loading a session: 
```
FileType
FileType
FileType
```
Autocommands triggered after the fix when loading a session:
```
BufReadPre
BufRead
BufReadPost
FileType
FileType
```
