### PR TITLE
feat(alt file): save and restore alternate file.

### DIFF
--- a/lua/resession/layout.lua
+++ b/lua/resession/layout.lua
@@ -39,6 +39,7 @@ M.get_win_info = function(tabnr, winid, current_win)
     width = vim.api.nvim_win_get_width(winid),
     height = vim.api.nvim_win_get_height(winid),
     options = util.save_win_options(winid),
+    altfile = vim.api.nvim_win_call(winid, function() return vim.fn.getreg("#") end),
   })
   local winnr = vim.api.nvim_win_get_number(winid)
   if vim.fn.haslocaldir(winnr, tabnr) == 1 then
@@ -150,6 +151,9 @@ local function set_winlayout_data(layout, scale_factor, visit_data)
       vim.bo[bufnr].filetype = vim.bo[bufnr].filetype
       vim.o.eventignore = "all"
       vim.b[bufnr].resession_restore_last_pos = nil
+    end
+    if win.altfile and win.altfile ~= "" then
+      pcall(vim.fn.setreg, "#", win.altfile)
     end
     util.restore_win_options(win.winid, win.options)
     local width_scale = vim.wo.winfixwidth and 1 or scale_factor[1]


### PR DESCRIPTION
This change causes Resession to save and restore the alternate file for each window, if one is set. It is backwards compatible by guarding against the existence of `altfile` in the session data before attempting to set the alternate file, and the set call is wrapped in a `pcall` so any errors, such as if the alternate buffer no longer exists due to the file being deleted or renamed, won't affect the rest of the plugin from functioning.

I initially tried to implement this as an extension, but the alternate file is a little strange. While it is stored in the global `#` register, it is tracked per window. (changing windows must cause neo/vim to update this register). There is no reference to this alternate file on the window itself (eg via `vim.fn.getwininfo(winid)`) so it's unclear how neo/vim tracks this. So while an extension can iterate over all windows (eg via `vim.api.nvim_list_wins()`) and store them in a list, there is no reference back to any meaningful window identifier, since window ids can differ per session. There is also no guarantee that I can find that `vim.api.nvim_list_wins()` will list the windows in the same order as `vim.fn.winlayout(tabnr)` as used by Recession, or that the order still holds across multiple tabs.

Using the extension window hooks (`save/load_win`) doesn't work, it appears those are intended exclusively for non-file windows and if an extension is attempting to do something here, then Resession skips loading the file buffer.

So the only reliable way for an extension to implement this feature would be to copy a good chunk of the tab/window recursive code to ensure the alternate files are saved and loaded in the correct order as the windows. While feels not great. It also feels like this is a nice feature to have in the core library, it's sort of a property of the window even if internally in neo/vim it might be handled strangely. I don't feel like this needs to be a user option, but it could be added if you felt strongly about it.

The new API used, `vim.api.nvim_win_call`, has existed since neovim 0.5.0.