### PR TITLE
fix: skip session saving when a tabpage is in visual mode

### DIFF
--- a/lua/resession/init.lua
+++ b/lua/resession/init.lua
@@ -227,7 +227,10 @@ local function save(name, opts, target_tabpage)
       options = target_tabpage and {} or util.save_global_options(),
     },
   }
-  local current_win = vim.api.nvim_get_current_win()
+  if vim.fn.mode():match("[vV\22]") ~= nil then
+    -- Prefer not saving rather than disrupting visual mode workflow
+    return
+  end
   local tabpage_bufs = {}
   if target_tabpage then
     for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(target_tabpage)) do


### PR DESCRIPTION
This PR makes a change to avoid an issue I've been running into daily for a long time (but didn't realize it was resession doing it) where if you are in visual mode and the session save interval triggers, you will be dropped out of visual mode. This is very disruptive if you are in the middle of running some visual mode key sequence.

Seems this behavior occurs because of the tabpage switching, where returning to the `current_tabpage` after the loop doesn't restore visual mode:

```lua
  local current_tabpage = vim.api.nvim_get_current_tabpage()
  local tabpages = target_tabpage and { target_tabpage } or vim.api.nvim_list_tabpages()
  for _, tabpage in ipairs(tabpages) do
    vim.api.nvim_set_current_tabpage(tabpage)
    local tab = {}
    local tabnr = vim.api.nvim_tabpage_get_number(tabpage)
    if target_tabpage or vim.fn.haslocaldir(-1, tabnr) == 1 then
      tab.cwd = vim.fn.getcwd(-1, tabnr)
    end
    tab.options = util.save_tab_options(tabpage)
    table.insert(data.tabs, tab)
    local winlayout = vim.fn.winlayout(tabnr)
    tab.wins = layout.add_win_info_to_layout(tabnr, winlayout, current_win)
  end
  vim.api.nvim_set_current_tabpage(current_tabpage)
```

To replicate the issue set your interval to something low (like 5 seconds), load a session, visually select some lines, and wait. You will see when the interval hits the visual selection disappears. This will happen every time.

To fix the issue I just bail if the current tabpage is in visual mode. A caveat to this approach is if by chance you are in visual mode every time the interval fires, some time might pass before your session actually saves, but I think it's probably okay in practice?

A better solution would likely be to detect visual mode, record the cursor position, then schedule a function, to run after the save function stops ignoring events, that restores the mode and selection. I opted to just send a simpler PR for now though. Happy if you prefer a better way to fix/avoid this.